### PR TITLE
feat: use new LLB merge operation, allow `from:` in deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Internal dependency:
 ```yaml
 - stage: gcc
   runtime: false
+  from: /
   to: /
 ```
 
@@ -248,6 +249,7 @@ Properties:
 - `stage` (*str*, *internal dependency*): name of other package this package depends on. Circular dependencies are not allowed. Contents of the stage are poured into the build at the location specified with `to:` parameter.
 - `image` (*str*, *external dependency*): reference to the registry container image this package depends on. Contents of the image are poured into the build at the location specified with `to:` parameter.
 - `runtime` (*bool*, *optional*): if set, marks dependency as runtime. This means that when this package is pulled in into the build, all the runtime dependencies are pulled in automatically as well. This also applies to transitive runtime dependencies.
+- `from` (*str*, *optional*, default `/`): base path to copy from the dependency.
 - `to` (*str*, *optional*, default `/`): location to copy dependency contents to.
 
 ### `steps`

--- a/internal/pkg/types/v1alpha2/deps.go
+++ b/internal/pkg/types/v1alpha2/deps.go
@@ -14,6 +14,7 @@ import (
 type Dependency struct {
 	Image   string `yaml:"image,omitempty"`
 	Stage   string `yaml:"stage,omitempty"`
+	From    string `yaml:"from,omitempty"`
 	To      string `yaml:"to,omitempty"`
 	Runtime bool   `yaml:"runtime,omitempty"`
 }
@@ -25,6 +26,10 @@ func (d *Dependency) IsInternal() bool {
 
 // Src returns copy source (from dependency).
 func (d *Dependency) Src() string {
+	if d.From != "" {
+		return d.From
+	}
+
 	return "/"
 }
 


### PR DESCRIPTION
This uses new Buildkit `Merge` operation which is exposed as
`COPY --link`. This speeds up builds a lot as eliminates some `COPY`
operations completely, and skips the `diff` stage between layers.

Also allow `--from` in `dependencies` to implement full equivalent of
`Dockerfile` `COPY` instruction.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>