### PR TITLE
feat: support build behind proxy.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ COMMON_ARGS += --platform=$(PLATFORM)
 COMMON_ARGS += --build-arg=VERSION=$(TAG)
 COMMON_ARGS += --build-arg=USERNAME=$(USERNAME)
 COMMON_ARGS += --build-arg=REGISTRY=$(REGISTRY)
+COMMON_ARGS += --build-arg=http_proxy=$(http_proxy)
+COMMON_ARGS += --build-arg=https_proxy=$(https_proxy)
 
 PKGS := frontend bldr
 


### PR DESCRIPTION
Adds support for building bldr behind http proxy.

Signed-off-by: Niklas Wik <niklas.wik@nokia.com>