### PR TITLE
feat: implement --no-cache option

### DIFF
--- a/internal/pkg/convert/node.go
+++ b/internal/pkg/convert/node.go
@@ -265,6 +265,10 @@ func (node *NodeLLB) stepScripts(root llb.State, i int, step v1alpha2.Step) llb.
 				llb.WithCustomName(fmt.Sprintf("%s%s-%d", node.Prefix, script.Desc, i)),
 			)
 
+			if node.Graph.Options.NoCache {
+				runOptions = append(runOptions, llb.IgnoreCache)
+			}
+
 			root = root.Run(runOptions...).Root()
 		}
 	}

--- a/internal/pkg/environment/options.go
+++ b/internal/pkg/environment/options.go
@@ -21,6 +21,7 @@ type Options struct {
 	ProxyEnv         *llb.ProxyEnv
 	SourceDateEpoch  time.Time
 	CacheIDNamespace string
+	NoCache          bool
 }
 
 // GetVariables returns set of variables set for options.

--- a/internal/pkg/pkgfile/build.go
+++ b/internal/pkg/pkgfile/build.go
@@ -30,6 +30,7 @@ const (
 	keyTarget         = "target"
 	keyTargetPlatform = "platform"
 	keyMultiPlatform  = "multi-platform"
+	keyNoCache        = "no-cache"
 
 	buildArgPrefix          = "build-arg:"
 	buildArgSourceDateEpoch = buildArgPrefix + "SOURCE_DATE_EPOCH"
@@ -47,6 +48,7 @@ func Build(ctx context.Context, c client.Client, options *environment.Options) (
 
 	options.Target = opts[keyTarget]
 	options.ProxyEnv = proxyEnvFromBuildArgs(filter(opts, buildArgPrefix))
+	_, options.NoCache = opts[keyNoCache]
 
 	if sourceDateEpoch, ok := opts[buildArgSourceDateEpoch]; ok {
 		timestamp, err := strconv.ParseInt(sourceDateEpoch, 10, 64)


### PR DESCRIPTION
If standard `--no-cache` option is specified, `bldr` adds option to ignore cache for all `RUN` steps: all download stages are still cached, but all prepare/build/install stages are run once again.

This is very helpful for reproducibility testing.