### PR TITLE
feat: add debian variant

### DIFF
--- a/internal/pkg/constants/build.go
+++ b/internal/pkg/constants/build.go
@@ -10,6 +10,10 @@ import "os"
 // renovate: datasource=docker versioning=docker depName=alpine
 const DefaultBaseImage = "docker.io/alpine:3.18"
 
+// DefaultDebianImage for debian builds.
+// renovate: datasource=docker versioning=docker depName=debian
+const DefaultDebianImage = "docker.io/debian:12.0-slim"
+
 // DefaultDirMode is UNIX file mode for mkdir.
 const DefaultDirMode os.FileMode = 0o755
 

--- a/internal/pkg/convert/graph.go
+++ b/internal/pkg/convert/graph.go
@@ -101,6 +101,22 @@ func (graph *GraphLLB) buildBaseImages() {
 		)...,
 	).Root())
 
+	graph.BaseImages[v1alpha2.Debian] = graph.baseImageProcessor(llb.Image(
+		constants.DefaultDebianImage,
+		llb.WithCustomName(graph.Options.CommonPrefix+"base"),
+	).Run(
+		append(graph.commonRunOptions,
+			llb.Shlex("apt update -qq"),
+			llb.WithCustomName(graph.Options.CommonPrefix+"base-aptupdate"),
+		)...,
+	).Run(
+		append(graph.commonRunOptions,
+			// debian image has /bin/sh symlinked to /bin/dash, let's change it to bash
+			llb.Args([]string{"ln", "-svf", "/bin/bash", "/bin/sh"}),
+			llb.WithCustomName(graph.Options.CommonPrefix+"base-symlink"),
+		)...,
+	).Root())
+
 	graph.BaseImages[v1alpha2.Scratch] = graph.baseImageProcessor(llb.Scratch())
 }
 

--- a/internal/pkg/solver/graph.go
+++ b/internal/pkg/solver/graph.go
@@ -56,7 +56,7 @@ func (node *PackageNode) DumpDot(g *dot.Graph) dot.Node {
 	}
 
 	for _, dep := range node.Pkg.Install {
-		packageNode := g.Node("Alpine: " + dep)
+		packageNode := g.Node(node.Pkg.Variant.String() + ": " + dep)
 		packageNode.Box()
 		packageNode.Attr("fillcolor", "aquamarine")
 		packageNode.Attr("style", "filled")

--- a/internal/pkg/types/v1alpha2/variant.go
+++ b/internal/pkg/types/v1alpha2/variant.go
@@ -14,10 +14,12 @@ const (
 	Alpine Variant = iota
 	// Scratch variant uses scratch image as base image for the build.
 	Scratch
+	// Debian variant uses Debian as base image for the build.
+	Debian
 )
 
 func (v Variant) String() string {
-	return []string{"alpine", "scratch"}[v]
+	return []string{"alpine", "scratch", "debian"}[v]
 }
 
 // UnmarshalYAML implements yaml.Unmarshaller interface.
@@ -35,6 +37,8 @@ func (v *Variant) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		val = Alpine
 	case Scratch.String():
 		val = Scratch
+	case Debian.String():
+		val = Debian
 	default:
 		return fmt.Errorf("unknown variant %q", aux)
 	}


### PR DESCRIPTION
This adds a debian variant to be used as a base when building glibc based toolchain.