### PR TITLE
fix: drop alpine for `md5sum` step

### DIFF
--- a/internal/pkg/constants/build.go
+++ b/internal/pkg/constants/build.go
@@ -24,3 +24,7 @@ const VarsYaml = "vars.yaml"
 
 // Pkgfile is the filename of 'Pkgfile'.
 const Pkgfile = "Pkgfile"
+
+// StageXBusyboxImage is the image name for busybox from stageX.
+// renovate: datasource=docker versioning=docker depName=siderolabs/stagex/core-busybox
+const StageXBusyboxImage = "ghcr.io/siderolabs/stagex/core-busybox:1.36.1@sha256:c0b551b47d8f1ac2fd5f4712eafddb8717e6e563a47203e02f94f944f64c18b2"

--- a/internal/pkg/convert/graph.go
+++ b/internal/pkg/convert/graph.go
@@ -108,14 +108,9 @@ func (graph *GraphLLB) buildBaseImages() {
 
 func (graph *GraphLLB) buildChecksummer() {
 	graph.Checksummer = llb.Image(
-		constants.DefaultBaseImage,
+		constants.StageXBusyboxImage,
 		llb.WithCustomName(graph.Options.CommonPrefix+"cksum"),
-	).Run(
-		append(graph.commonRunOptions,
-			llb.Shlex("apk --no-cache --update add coreutils"),
-			llb.WithCustomName(graph.Options.CommonPrefix+"cksum-apkinstall"),
-		)...,
-	).Root()
+	)
 }
 
 func (graph *GraphLLB) buildLocalContext() {

--- a/internal/pkg/convert/node.go
+++ b/internal/pkg/convert/node.go
@@ -230,8 +230,9 @@ func (node *NodeLLB) stepDownload(root llb.State, step v1alpha2.Step) llb.State 
 			llb.WithCustomName(node.Prefix+"cksum-prepare"),
 		).Run(
 			append(node.Graph.commonRunOptions,
-				llb.Shlex("sha512sum -c --strict /checksums"),
+				llb.Shlex("sha512sum -c -w /checksums"),
 				llb.WithCustomName(node.Prefix+"cksum-verify"),
+				llb.Network(pb.NetMode_NONE),
 			)...,
 		).Root()
 


### PR DESCRIPTION
Use [StageX](https://stagex.tools/) instead.

Fixes #182