### PR TITLE
feat: add `name` parameter to override names in SBOM

### DIFF
--- a/internal/pkg/integration/testdata/sbom/final/pkg.yaml
+++ b/internal/pkg/integration/testdata/sbom/final/pkg.yaml
@@ -5,6 +5,9 @@ dependencies:
   - stage: pkg
 steps:
 - test:
+    - cp /pkg/runc.json /tmp/runc.json
+    - sed -i 's/BLDR_TAG/{{ .BUILD_ARG_BLDR_TAG }}/g' /tmp/runc.json
+    - diff /tmp/runc.json /rootfs/usr/share/spdx/runc.spdx.json
     - cp /pkg/ref.json /tmp/ref.json
     - sed -i 's/BLDR_TAG/{{ .BUILD_ARG_BLDR_TAG }}/g' /tmp/ref.json
     - diff /tmp/ref.json /rootfs/usr/share/spdx/containerd.spdx.json

--- a/internal/pkg/integration/testdata/sbom/final/runc.json
+++ b/internal/pkg/integration/testdata/sbom/final/runc.json
@@ -1,0 +1,65 @@
+{
+ "spdxVersion": "SPDX-2.3",
+ "dataLicense": "CC0-1.0",
+ "SPDXID": "SPDXRef-DOCUMENT",
+ "name": "sidero-pkgs-runc",
+ "documentNamespace": "https://anchore.com/bldr/dir/sidero-pkgs-runc-096b39da-b937-5033-a23e-9554b61f75e8",
+ "creationInfo": {
+  "licenseListVersion": "3.25",
+  "creators": [
+   "Organization: Anchore, Inc",
+   "Tool: bldr-BLDR_TAG"
+  ],
+  "created": "0001-01-01T00:00:00Z"
+ },
+ "packages": [
+  {
+   "name": "runc",
+   "SPDXID": "SPDXRef-Package-bldr-package-runc-e3c63cb53b493066",
+   "versionInfo": "1.3.0",
+   "supplier": "NOASSERTION",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from the following paths: /Pkgfile",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "Apache-2.0",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:opencontainers:runc:1.3.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:linuxfoundation:runc:1.3.0:*:*:*:*:*:*:*"
+    }
+   ]
+  },
+  {
+   "name": "sidero-pkgs-runc",
+   "SPDXID": "SPDXRef-DocumentRoot-Directory-sidero-pkgs-runc",
+   "versionInfo": "1.3.0",
+   "supplier": "NOASSERTION",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "NOASSERTION",
+   "copyrightText": "NOASSERTION",
+   "primaryPackagePurpose": "FILE"
+  }
+ ],
+ "relationships": [
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-sidero-pkgs-runc",
+   "relatedSpdxElement": "SPDXRef-Package-bldr-package-runc-e3c63cb53b493066",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DOCUMENT",
+   "relatedSpdxElement": "SPDXRef-DocumentRoot-Directory-sidero-pkgs-runc",
+   "relationshipType": "DESCRIBES"
+  }
+ ]
+}

--- a/internal/pkg/integration/testdata/sbom/pkg/pkg.yaml
+++ b/internal/pkg/integration/testdata/sbom/pkg/pkg.yaml
@@ -3,6 +3,15 @@ name: pkg
 variant: scratch
 steps:
 - sbom:
+    outputPath: /rootfs/usr/share/spdx/runc.spdx.json
+    name: runc
+    version: 1.3.0
+    cpes:
+      - cpe:2.3:a:opencontainers:runc:1.3.0:*:*:*:*:*:*:*
+      - cpe:2.3:a:linuxfoundation:runc:1.3.0:*:*:*:*:*:*:*
+    licenses:
+      - Apache-2.0
+- sbom:
     outputPath: /rootfs/usr/share/spdx/containerd.spdx.json
     version: 2.1.2
     cpes:

--- a/internal/pkg/sbom/sbom.go
+++ b/internal/pkg/sbom/sbom.go
@@ -71,11 +71,16 @@ func CreatePackageSBOM(bldrPkg *v1alpha2.Pkg, sbomMetadata v1alpha2.SBOMStep) (*
 		return nil, err
 	}
 
+	name := bldrPkg.Name
+	if sbomMetadata.Name != "" {
+		name = sbomMetadata.Name
+	}
+
 	sbomDoc := &sbom.SBOM{
 		Source: source.Description{
 			ID:       "sidero-pkgs",
 			Metadata: source.DirectoryMetadata{},
-			Name:     "sidero-pkgs-" + bldrPkg.Name,
+			Name:     "sidero-pkgs-" + name,
 			Version:  sbomMetadata.Version,
 		},
 		Descriptor: sbom.Descriptor{
@@ -90,7 +95,7 @@ func CreatePackageSBOM(bldrPkg *v1alpha2.Pkg, sbomMetadata v1alpha2.SBOMStep) (*
 	}
 
 	syftPkg := pkg.Package{
-		Name:    bldrPkg.Name,
+		Name:    name,
 		Version: sbomMetadata.Version,
 		PURL:    sbomMetadata.PURL,
 		Type:    pkg.Type("bldr-package"),

--- a/internal/pkg/types/v1alpha2/sbom.go
+++ b/internal/pkg/types/v1alpha2/sbom.go
@@ -7,6 +7,7 @@ package v1alpha2
 // SBOMStep is a step with data to generate an SBOM (Software Bill of Materials) for the package.
 type SBOMStep struct {
 	OutputPath string   `yaml:"outputPath,omitempty"`
+	Name       string   `yaml:"name,omitempty"`
 	Version    string   `yaml:"version,omitempty"`
 	CPEs       []string `yaml:"cpes,omitempty"`
 	PURL       string   `yaml:"purl,omitempty"`


### PR DESCRIPTION
This is useful to not disrupt naming schemes, but only change names in
the SBOMs.

Signed-off-by: Dmitrii Sharshakov <dmitry.sharshakov@siderolabs.com>
