### PR TITLE
fix: update graph for build-arg support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-08-20T12:12:40Z by kres 18c31cf.
+# Generated on 2025-09-04T12:37:31Z by kres 784fa1f.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: gather-system-info
         id: system-info
-        uses: kenchan0130/actions-system-info@v1.4.0
+        uses: kenchan0130/actions-system-info@v1.3.1
         continue-on-error: true
       - name: print-system-info
         run: |

--- a/internal/pkg/solver/filesystem_loader.go
+++ b/internal/pkg/solver/filesystem_loader.go
@@ -218,8 +218,20 @@ func (fspl *FilesystemPackageLoader) attachTemplate(path string) (*v1alpha2.Pkg,
 		shortestRel string
 	)
 
+	absFile, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+
+	relPath, err := filepath.Rel(fspl.absRootPath, absFile)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, pkg := range fspl.pkgs {
-		rel, err := filepath.Rel(pkg.BaseDir, filepath.Dir(path))
+		var rel string
+
+		rel, err = filepath.Rel(pkg.BaseDir, filepath.Dir(relPath))
 		if err != nil || strings.HasPrefix(rel, "..") {
 			continue
 		}

--- a/internal/pkg/solver/packages.go
+++ b/internal/pkg/solver/packages.go
@@ -41,6 +41,15 @@ func NewPackages(loader PackageLoader) (*Packages, error) {
 	return result, nil
 }
 
+// FilterInPlace filters packages in place using the given filter function.
+func (pkgs *Packages) FilterInPlace(f func(pkg *v1alpha2.Pkg) bool) {
+	for name, pkg := range pkgs.packages {
+		if !f(pkg) {
+			delete(pkgs.packages, name)
+		}
+	}
+}
+
 func (pkgs *Packages) resolve(name string, path []string, cache map[string]*PackageNode) (*PackageNode, error) {
 	if node := cache[name]; node != nil {
 		return node, nil


### PR DESCRIPTION
Support build-arg in graph command, fix filesystem loader for non-root paths (for `docker run`), add automatic filtering out of nodes for e.g. `reproducibility` and `grype-scan` targets.