### PR TITLE
feat: support riscv64 architecture

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,7 +13,7 @@
             "customType": "regex",
             "versioningTemplate": "{{#if versioning}}{{versioning}}{{else}}semver{{/if}}",
             "managerFilePatterns": [
-                "/internal/pkg/constants/build.go/"
+                "/internal/pkg/constants/constants.go/"
             ],
             "matchStrings": [
                 "\\/\\/\\s+renovate: datasource=(?<datasource>.*?)(?:\\s+extractVersion=(?<extractVersion>.+?))?(?:\\s+versioning=(?<versioning>.+?))?\\s+depName=(?<depName>.+?)?\\s.*Image\\s+=\\s+\\\"docker.io\\/alpine:(?<currentValue>.+?)\\\""

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-12-05T14:08:35Z by kres 571923f.
+# Generated on 2025-12-31T05:18:26Z by kres 26be706.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -55,7 +55,7 @@ jobs:
           done
         continue-on-error: true
       - name: checkout
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # version: v6.0.0
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # version: v6.0.1
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
@@ -141,7 +141,7 @@ jobs:
           done
         continue-on-error: true
       - name: checkout
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # version: v6.0.0
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # version: v6.0.1
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
@@ -190,7 +190,7 @@ jobs:
           done
         continue-on-error: true
       - name: checkout
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # version: v6.0.0
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # version: v6.0.1
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
@@ -237,7 +237,7 @@ jobs:
           done
         continue-on-error: true
       - name: checkout
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # version: v6.0.0
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # version: v6.0.1
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
@@ -255,7 +255,7 @@ jobs:
         run: |
           make unit-tests-race
       - name: coverage
-        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # version: v5.5.1
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # version: v5.5.2
         with:
           files: _out/coverage-unit-tests.txt
           flags: unit-tests

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-12-05T14:08:35Z by kres 571923f.
+# Generated on 2025-12-31T05:18:26Z by kres 26be706.
 
 "on":
   schedule:
@@ -14,7 +14,7 @@ jobs:
       - ubuntu-latest
     steps:
       - name: Lock old issues
-        uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # version: v5.0.1
+        uses: dessant/lock-threads@7266a7ce5c1df01b1c6db85bf8cd86c737dadbe7 # version: v6.0.0
         with:
           issue-inactive-days: "60"
           log-output: "true"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-12-05T14:08:35Z by kres 571923f.
+# Generated on 2025-12-31T05:18:26Z by kres 26be706.
 
 "on":
   schedule:
@@ -15,7 +15,7 @@ jobs:
       - ubuntu-latest
     steps:
       - name: Close stale issues and PRs
-        uses: actions/stale@5f858e3efba33a5ca4407a664cc011ad407f2008 # version: v10.1.0
+        uses: actions/stale@997185467fa4f803885201cee163a9f38240193d # version: v10.1.1
         with:
           close-issue-message: This issue was closed because it has been stalled for 7 days with no activity.
           days-before-issue-close: "5"

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -118,7 +118,7 @@ spec:
   customManagers:
     - customType: regex
       managerFilePatterns:
-        - internal/pkg/constants/build.go
+        - internal/pkg/constants/constants.go
       matchStrings:
         - '\/\/\s+renovate: datasource=(?<datasource>.*?)(?:\s+extractVersion=(?<extractVersion>.+?))?(?:\s+versioning=(?<versioning>.+?))?\s+depName=(?<depName>.+?)?\s.*Image\s+=\s+\"docker.io\/alpine:(?<currentValue>.+?)\"'
       versioningTemplate: "{{#if versioning}}{{versioning}}{{else}}semver{{/if}}"

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -17,6 +17,9 @@ spec:
     linux-arm64:
       GOOS: linux
       GOARCH: arm64
+    linux-riscv64:
+      GOOS: linux
+      GOARCH: riscv64
     darwin-amd64:
       GOOS: darwin
       GOARCH: amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@
 
 ARG TOOLCHAIN=scratch
 
-FROM ghcr.io/siderolabs/ca-certificates:v1.12.0 AS image-ca-certificates
+FROM --platform=linux/amd64 ghcr.io/siderolabs/ca-certificates:v1.12.0 AS image-ca-certificates
 
-FROM ghcr.io/siderolabs/fhs:v1.12.0 AS image-fhs
+FROM --platform=linux/amd64 ghcr.io/siderolabs/fhs:v1.12.0 AS image-fhs
 
 # runs markdownlint
 FROM docker.io/oven/bun:1.3.1-alpine AS lint-markdown

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,16 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-12-05T14:08:35Z by kres 571923f.
+# Generated on 2025-12-31T05:18:26Z by kres 26be706.
 
 # common variables
 
 SHA := $(shell git describe --match=none --always --abbrev=8 --dirty)
 TAG := $(shell git describe --tag --always --dirty --match v[0-9]\*)
+TAG_SUFFIX ?=
 ABBREV_TAG := $(shell git describe --tags >/dev/null 2>/dev/null && git describe --tag --always --match v[0-9]\* --abbrev=0 || echo 'undefined')
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 ARTIFACTS := _out
-IMAGE_TAG ?= $(TAG)
+IMAGE_TAG ?= $(TAG)$(TAG_SUFFIX)
 OPERATING_SYSTEM := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 GOARCH := $(shell uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
 WITH_DEBUG ?= false
@@ -17,21 +18,23 @@ WITH_RACE ?= false
 REGISTRY ?= ghcr.io
 USERNAME ?= siderolabs
 REGISTRY_AND_USERNAME ?= $(REGISTRY)/$(USERNAME)
-PROTOBUF_GO_VERSION ?= 1.36.10
+PROTOBUF_GO_VERSION ?= 1.36.11
 GRPC_GO_VERSION ?= 1.6.0
 GRPC_GATEWAY_VERSION ?= 2.27.3
 VTPROTOBUF_VERSION ?= 0.6.0
-GOIMPORTS_VERSION ?= 0.39.0
+GOIMPORTS_VERSION ?= 0.40.0
 GOMOCK_VERSION ?= 0.6.0
 DEEPCOPY_VERSION ?= v0.5.8
-GOLANGCILINT_VERSION ?= v2.6.2
+GOLANGCILINT_VERSION ?= v2.7.2
 GOFUMPT_VERSION ?= v0.9.2
-GO_VERSION ?= 1.25.4
+GO_VERSION ?= 1.25.5
 GO_BUILDFLAGS ?=
+GO_BUILDTAGS ?= ,
 GO_LDFLAGS ?=
 CGO_ENABLED ?= 0
 GOTOOLCHAIN ?= local
 GOEXPERIMENT ?=
+GO_BUILDFLAGS += -tags $(GO_BUILDTAGS)
 TESTPKGS ?= ./...
 KRES_IMAGE ?= ghcr.io/siderolabs/kres:latest
 CONFORMANCE_IMAGE ?= ghcr.io/siderolabs/conform:latest
@@ -135,7 +138,7 @@ GO_LDFLAGS += -linkmode=external -extldflags '-static'
 endif
 
 ifneq (, $(filter $(WITH_DEBUG), t true TRUE y yes 1))
-GO_BUILDFLAGS += -tags sidero.debug
+GO_BUILDTAGS := $(GO_BUILDTAGS)sidero.debug,
 else
 GO_LDFLAGS += -s
 endif
@@ -230,8 +233,15 @@ $(ARTIFACTS)/bldr-linux-arm64:
 .PHONY: bldr-linux-arm64
 bldr-linux-arm64: $(ARTIFACTS)/bldr-linux-arm64  ## Builds executable for bldr-linux-arm64.
 
+.PHONY: $(ARTIFACTS)/bldr-linux-riscv64
+$(ARTIFACTS)/bldr-linux-riscv64:
+	@$(MAKE) local-bldr-linux-riscv64 DEST=$(ARTIFACTS)
+
+.PHONY: bldr-linux-riscv64
+bldr-linux-riscv64: $(ARTIFACTS)/bldr-linux-riscv64  ## Builds executable for bldr-linux-riscv64.
+
 .PHONY: bldr
-bldr: bldr-darwin-amd64 bldr-darwin-arm64 bldr-linux-amd64 bldr-linux-arm64  ## Builds executables for bldr.
+bldr: bldr-darwin-amd64 bldr-darwin-arm64 bldr-linux-amd64 bldr-linux-arm64 bldr-linux-riscv64  ## Builds executables for bldr.
 
 .PHONY: lint-markdown
 lint-markdown:  ## Runs markdownlint.

--- a/internal/pkg/constants/build.go
+++ b/internal/pkg/constants/build.go
@@ -6,10 +6,6 @@ package constants
 
 import "os"
 
-// DefaultBaseImage for non-scratch builds.
-// renovate: datasource=docker versioning=docker depName=alpine
-const DefaultBaseImage = "docker.io/alpine:3.21@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c"
-
 // DefaultDirMode is UNIX file mode for mkdir.
 const DefaultDirMode os.FileMode = 0o755
 
@@ -27,7 +23,3 @@ const Pkgfile = "Pkgfile"
 
 // TemplateExt extension.
 const TemplateExt = ".tmpl"
-
-// StageXBusyboxImage is the image name for busybox from stageX.
-// renovate: datasource=docker versioning=docker depName=siderolabs/stagex/core-busybox
-const StageXBusyboxImage = "ghcr.io/siderolabs/stagex/core-busybox:1.36.1@sha256:c0b551b47d8f1ac2fd5f4712eafddb8717e6e563a47203e02f94f944f64c18b2"

--- a/internal/pkg/constants/constants.go
+++ b/internal/pkg/constants/constants.go
@@ -10,4 +10,12 @@ var (
 	DefaultRegistry     string
 	DefaultOrganization string
 	Version             string
+
+	// DefaultBaseImage for non-scratch builds.
+	// renovate: datasource=docker versioning=docker depName=alpine
+	DefaultBaseImage = "docker.io/alpine:3.21@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c"
+
+	// StageXBusyboxImage is the image name for busybox from stageX.
+	// renovate: datasource=docker versioning=docker depName=siderolabs/stagex/core-busybox
+	StageXBusyboxImage = "ghcr.io/siderolabs/stagex/core-busybox:1.36.1@sha256:c0b551b47d8f1ac2fd5f4712eafddb8717e6e563a47203e02f94f944f64c18b2"
 )

--- a/internal/pkg/environment/platform.go
+++ b/internal/pkg/environment/platform.go
@@ -94,6 +94,16 @@ var (
 		LLBPlatform:  llb.LinuxArmhf,
 		PlatformSpec: platforms.MustParse("linux/arm7"),
 	}
+
+	LinuxRiscv64 = Platform{
+		ID:           "linux/riscv64",
+		Arch:         "riscv64",
+		Target:       "riscv64-talos-linux-musl",
+		Build:        "riscv64-linux-musl",
+		Host:         "riscv64-linux-musl",
+		LLBPlatform:  llb.Platform(specs.Platform{OS: "linux", Architecture: "riscv64"}),
+		PlatformSpec: platforms.MustParse("linux/riscv64"),
+	}
 )
 
 // Platforms is mapping of platform ID to Platform.
@@ -104,6 +114,7 @@ func init() {
 		LinuxAmd64,
 		LinuxArm64,
 		LinuxArmv7,
+		LinuxRiscv64,
 	} {
 		Platforms[platform.ID] = platform
 	}


### PR DESCRIPTION
The first dependency for running Talos on RISC-V, cc @shanduur. We've spoken about upstreaming my patches, then keeping CI/releases (and maybe bug reports?) on my forks to reduce the maintenance burden for Sidero Labs.

Not sure about terminology, maybe "experimental support for" or "enable building for"? So it's clear that official build artefacts and support won't be available.

I'm happy to remove the `.kres` changes too if preferred, so it's more like "support linux/riscv64 build targets".