### PR TITLE
feat: add buildPlatform to pin a package's build platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,9 +232,14 @@ On the root level, following properties are available:
   - `alpine`: Alpine Linux 3.16 image with `bash` package pre-installed
   - `scratch`: scratch (empty) image
   Default variant is `alpine`.
-- `install`: (*list*, *optional*): list of Alpine packages to be installed as part of the build.
+- `install` (*list*, *optional*): list of Alpine packages to be installed as part of the build.
   These packages are usually build dependencies.
-- `shell`: (*str*, *optional*): path to the shell to execute build step instructions, defaults to `/bin/sh`.
+- `shell` (*str*, *optional*): path to the shell to execute build step instructions, defaults to `/bin/sh`.
+- `buildPlatform` (*str*, *optional*): pin the platform the build runs on, independent of the requested target platform.
+  If not set, the build runs on the target platform (the usual native build).
+  When set (e.g. `linux/amd64`), the build steps execute on that platform while the requested target platform still determines the `ARCH`/`TARGET`/`CFLAGS` variables and the architecture of the produced image.
+  This enables cross-compilation: for example, building an `arm64` artifact on an `amd64` worker (no emulation), where the recipe reads `$BUILD` (`x86_64-linux-musl`) and `$TARGET` (`aarch64-...-musl`) to drive a cross-compiler.
+  It applies to the whole subgraph rooted at the package, so a cross-compiled package's build-time dependencies should be *external* images (they are pulled for the build platform).
 
 ### `dependencies`
 

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -16,3 +16,13 @@ pre_release = false
 The default CFLAGS/CXXFLAGS were updated to use `-O2` optimization level and
 use x86_64 v2 microarchitecture by default. This should improve performance on modern CPUs.
 """
+
+[notes.buildplatform]
+    title = "Build Platform"
+    description = """
+Packages can now pin the platform their build runs on with the `buildPlatform`
+field, independent of the requested target platform. This enables
+cross-compilation: e.g. building an `arm64` artifact on an `amd64` worker (no
+emulation), where `ARCH`/`TARGET` still describe the target while the build
+executes on `buildPlatform`.
+"""

--- a/internal/pkg/convert/graph.go
+++ b/internal/pkg/convert/graph.go
@@ -88,10 +88,18 @@ func (graph *GraphLLB) buildBaseImages() {
 		return addEnv(addPkg(root))
 	}
 
+	// Pin the base image to the build platform, like `FROM --platform=$BUILDPLATFORM`.
+	// This stamps the build platform onto every op derived from the base (RUN,
+	// COPY, …) so buildkit schedules them on the build-platform worker/node — the
+	// basis for cross-compilation. For a native build, build == target, so this is
+	// a no-op; for a cross build it keeps the heavy work on the build platform
+	// while dependencies pinned to the target platform are pulled as-is.
+	buildPlatform := graph.Options.BuildPlatform.PlatformSpec
+
 	graph.BaseImages[v1alpha2.Alpine] = graph.baseImageProcessor(llb.Image(
 		constants.DefaultBaseImage,
 		llb.WithCustomName(graph.Options.CommonPrefix+"base"),
-	).Run(
+	).Platform(buildPlatform).Run(
 		append(
 			graph.commonRunOptions,
 			llb.Shlex("apk --no-cache --update add bash"),
@@ -105,14 +113,17 @@ func (graph *GraphLLB) buildBaseImages() {
 		)...,
 	).Root())
 
-	graph.BaseImages[v1alpha2.Scratch] = graph.baseImageProcessor(llb.Scratch())
+	graph.BaseImages[v1alpha2.Scratch] = graph.baseImageProcessor(llb.Scratch().Platform(buildPlatform))
 }
 
 func (graph *GraphLLB) buildChecksummer() {
+	// Pin to the build platform: the checksum step runs `sha512sum` (an exec), so
+	// it must run on the build-platform worker rather than be emulated on the
+	// target one.
 	graph.Checksummer = llb.Image(
 		constants.StageXBusyboxImage,
 		llb.WithCustomName(graph.Options.CommonPrefix+"cksum"),
-	)
+	).Platform(graph.Options.BuildPlatform.PlatformSpec)
 }
 
 func (graph *GraphLLB) buildLocalContext() {

--- a/internal/pkg/convert/node.go
+++ b/internal/pkg/convert/node.go
@@ -122,10 +122,36 @@ func (node *NodeLLB) context(root llb.State) llb.State {
 
 func (node *NodeLLB) convertDependency(ctx context.Context, dep solver.PackageDependency) (depState llb.State, srcName string, err error) {
 	if dep.IsInternal() {
-		if dep.Platform != "" && dep.Platform != node.Graph.Options.BuildPlatform.ID {
+		// A dependency is a build input consumed on the platform this build
+		// executes on (BuildPlatform), unless it explicitly overrides its
+		// platform (e.g. a target-arch sysroot). It must be built in a clean
+		// single-platform (build == target) context at that platform.
+		depPlatform := node.Graph.Options.BuildPlatform.ID
+		if dep.Platform != "" {
+			depPlatform = dep.Platform
+		}
+
+		// Building inline shares the current graph's options, which is only
+		// correct when this is not a cross build (BuildPlatform == TargetPlatform)
+		// and the dependency wants that same platform. Otherwise (cross build, or
+		// a platform override) re-solve the dependency at its own platform so it
+		// builds natively there rather than inheriting the parent's target arch.
+		crossBuild := node.Graph.Options.BuildPlatform.ID != node.Graph.Options.TargetPlatform.ID
+
+		if !crossBuild && depPlatform == node.Graph.Options.BuildPlatform.ID {
+			depState, err = NewNodeLLB(dep.Node, node.Graph).Build(ctx)
+			if err != nil {
+				return llb.Scratch(), "", err
+			}
+		} else {
+			platform, ok := environment.Platforms[depPlatform]
+			if !ok {
+				return llb.Scratch(), "", fmt.Errorf("platform %q not supported", depPlatform)
+			}
+
 			var res *client.Result
 
-			res, err = node.Graph.solverFn(ctx, environment.Platforms[dep.Platform], dep.Node.Name)
+			res, err = node.Graph.solverFn(ctx, platform, dep.Node.Name)
 			if err != nil {
 				return llb.Scratch(), "", err
 			}
@@ -138,11 +164,6 @@ func (node *NodeLLB) convertDependency(ctx context.Context, dep solver.PackageDe
 			}
 
 			depState, err = ref.ToState()
-			if err != nil {
-				return llb.Scratch(), "", err
-			}
-		} else {
-			depState, err = NewNodeLLB(dep.Node, node.Graph).Build(ctx)
 			if err != nil {
 				return llb.Scratch(), "", err
 			}

--- a/internal/pkg/integration/testdata/cross-compile/Pkgfile
+++ b/internal/pkg/integration/testdata/cross-compile/Pkgfile
@@ -1,0 +1,3 @@
+# syntax = SHEBANG
+
+format: v1alpha2

--- a/internal/pkg/integration/testdata/cross-compile/buildhelper/pkg.yaml
+++ b/internal/pkg/integration/testdata/cross-compile/buildhelper/pkg.yaml
@@ -1,0 +1,21 @@
+---
+name: buildhelper
+variant: alpine
+# A build-time dependency of the cross-compiled `final` package. It has no
+# `platform` override, so it is re-solved natively on the *build* platform
+# (amd64) rather than inheriting the parent's arm64 target. This exercises the
+# cross-build subgraph path in convertDependency.
+steps:
+- prepare:
+    - mkdir -p /out
+    - touch /out/buildhelper
+  test:
+    # re-solved natively on the build platform (amd64): build == target == amd64
+    - test `uname -m` = "x86_64"
+    - test "${BUILD:-x}" = "x86_64-linux-musl"
+    - test "${HOST:-x}" = "x86_64-linux-musl"
+    - test "${ARCH:-x}" = "x86_64"
+    - test "${TARGET:-x}" = "x86_64-talos-linux-musl"
+finalize:
+  - from: /out
+    to: /buildhelper

--- a/internal/pkg/integration/testdata/cross-compile/final/pkg.yaml
+++ b/internal/pkg/integration/testdata/cross-compile/final/pkg.yaml
@@ -1,0 +1,30 @@
+---
+name: final
+variant: alpine
+# Pin the build to amd64 while the requested target platform is arm64: the build
+# runs on an amd64 worker (no emulation) yet ARCH/TARGET describe arm64, so the
+# recipe can cross-compile. See README "buildPlatform".
+buildPlatform: linux/amd64
+dependencies:
+  # Build-time helper with no platform override: re-solved natively on the build
+  # platform (amd64). Its rootfs (/buildhelper/...) is merged into this build.
+  - stage: buildhelper
+  # Target-arch sysroot pinned to arm64: re-solved natively on arm64 even though
+  # this package cross-builds on amd64. Its rootfs (/sysroot/...) is merged in.
+  - stage: sysroot
+    platform: linux/arm64
+steps:
+- test:
+    # exec runs on the build platform (amd64), not the arm64 target
+    - test `uname -m` = "x86_64"
+    - test "${BUILD:-x}" = "x86_64-linux-musl"
+    - test "${HOST:-x}" = "x86_64-linux-musl"
+    # ARCH/TARGET still describe the requested target platform (arm64)
+    - test "${ARCH:-x}" = "aarch64"
+    - test "${TARGET:-x}" = "aarch64-talos-linux-musl"
+    # outputs of both dependencies (built on different platforms) are present
+    - test -f /buildhelper/buildhelper
+    - test -f /sysroot/sysroot
+finalize:
+  - from: /
+    to: /

--- a/internal/pkg/integration/testdata/cross-compile/sysroot/pkg.yaml
+++ b/internal/pkg/integration/testdata/cross-compile/sysroot/pkg.yaml
@@ -1,0 +1,20 @@
+---
+name: sysroot
+variant: alpine
+# A target-arch sysroot dependency: even though the parent `final` package
+# cross-builds on amd64, this dependency carries an explicit `platform: linux/arm64`
+# (set on the dependency reference), so it is re-solved natively on arm64.
+steps:
+- prepare:
+    - mkdir -p /out
+    - touch /out/sysroot
+  test:
+    # re-solved natively on arm64: build == target == arm64
+    - test `uname -m` = "aarch64"
+    - test "${BUILD:-x}" = "aarch64-linux-musl"
+    - test "${HOST:-x}" = "aarch64-linux-musl"
+    - test "${ARCH:-x}" = "aarch64"
+    - test "${TARGET:-x}" = "aarch64-talos-linux-musl"
+finalize:
+  - from: /out
+    to: /sysroot

--- a/internal/pkg/integration/testdata/cross-compile/test.yaml
+++ b/internal/pkg/integration/testdata/cross-compile/test.yaml
@@ -1,0 +1,7 @@
+---
+run:
+  - name: docker
+    runner: docker
+    platform: linux/arm64
+    target: final
+    expect: success

--- a/internal/pkg/pkgfile/build.go
+++ b/internal/pkg/pkgfile/build.go
@@ -134,6 +134,20 @@ func solveTarget(
 			return nil, fmt.Errorf("failed to resolve packages for platform %s and target %s: %w", platform, target, err)
 		}
 
+		// A package may pin the platform it is built on independently of the
+		// target platform (e.g. cross-compile an arm64 artifact on an amd64
+		// node). TargetPlatform is left untouched, so the output image is still
+		// labeled with the requested target and ARCH/TARGET reflect it, while
+		// BUILD/HOST and LLB exec placement follow the build platform.
+		if buildPlatform := graph.Root.Pkg.BuildPlatform; buildPlatform != "" {
+			p, ok := environment.Platforms[buildPlatform]
+			if !ok {
+				return nil, fmt.Errorf("package %q: buildPlatform %q is not supported", graph.Root.Name, buildPlatform)
+			}
+
+			options.BuildPlatform = p
+		}
+
 		def, err := convert.MarshalLLB(ctx, graph, solveTarget(platformContextCache, c, cacheImports), &options)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal LLB for platform %s and target %s: %w", platform, target, err)

--- a/internal/pkg/types/v1alpha2/pkg.go
+++ b/internal/pkg/types/v1alpha2/pkg.go
@@ -25,6 +25,7 @@ type Pkg struct {
 	Shell          Shell           `yaml:"shell,omitempty"`
 	BaseDir        string          `yaml:"-"`
 	FileName       string          `yaml:"-"`
+	BuildPlatform  string          `yaml:"buildPlatform,omitempty"`
 	Install        Install         `yaml:"install,omitempty"`
 	Dependencies   Dependencies    `yaml:"dependencies,omitempty"`
 	Steps          Steps           `yaml:"steps,omitempty"`

--- a/internal/pkg/util/testutil/runners.go
+++ b/internal/pkg/util/testutil/runners.go
@@ -41,7 +41,7 @@ func (runner CommandRunner) run(t *testing.T, cmd *exec.Cmd, title string) {
 			t.Fatalf("%s failed: %v", title, err)
 		}
 	case "fail":
-		if err != nil {
+		if err == nil {
 			t.Fatalf("%s should have failed, but succeeded", title)
 		}
 	default:


### PR DESCRIPTION
Add an optional root-level `buildPlatform` field to pkg.yaml that pins the platform a package's build runs on, independent of the requested target platform. When unset, behavior is unchanged (build runs on the target platform).

When set, the build steps execute on `buildPlatform` (LLB exec is placed on a matching worker, and BUILD/HOST reflect it), while the requested target platform still drives ARCH/TARGET/CFLAGS and the architecture of the produced image.